### PR TITLE
feat(panes): configurable kiosk mode to open panes in-place

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -75,15 +75,20 @@ impl State {
         let tiled_floating_control =
             Control::new_floating_control("Ctrl f", self.should_open_floating);
         let names_contents_control = Control::new_filter_control("Ctrl r", &self.search_filter);
+        let controls = if self.kiosk_mode {
+            vec![names_contents_control]
+        } else {
+            vec![tiled_floating_control, names_contents_control]
+        };
         if self.loading {
             ControlsLine::new(
-                vec![tiled_floating_control, names_contents_control],
+                controls,
                 Some(vec!["Scanning folder", "Scanning", "S"]),
             )
             .with_animation_offset(self.loading_animation_offset)
             .render(self.display_columns, has_results)
         } else {
-            ControlsLine::new(vec![tiled_floating_control, names_contents_control], None)
+            ControlsLine::new(controls, None)
                 .render(self.display_columns, has_results)
         }
     }


### PR DESCRIPTION
To enable, load the plugin with `kiosk true` in the layout, or with `--configuration kiosk=true` from the CLI.

This will make panes open in-place (on top of monocle) and I think it can be especially useful when loading monocle itself in-place (eg. `zellij plugin --in-place -- file:/path/to/monocle.wasm`)