### PR TITLE
Various fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,9 +50,6 @@ impl ZellijPlugin for State {
             EventType::Mouse,
             EventType::CustomMessage,
             EventType::Timer,
-            EventType::FileSystemCreate,
-            EventType::FileSystemUpdate,
-            EventType::FileSystemDelete,
         ]);
         post_message_to(PluginMessage::new_to_worker(
             "file_name_search",
@@ -102,54 +99,6 @@ impl ZellijPlugin for State {
             Event::Key(key) => {
                 self.handle_key(key);
                 should_render = true;
-            }
-            Event::FileSystemCreate(paths) => {
-                let paths: Vec<String> = paths
-                    .iter()
-                    .map(|p| p.to_string_lossy().to_string())
-                    .collect();
-                post_message_to(PluginMessage::new_to_worker(
-                    "file_name_search",
-                    &serde_json::to_string(&MessageToSearch::FileSystemCreate).unwrap(),
-                    &serde_json::to_string(&paths).unwrap(),
-                ));
-                post_message_to(PluginMessage::new_to_worker(
-                    "file_contents_search",
-                    &serde_json::to_string(&MessageToSearch::FileSystemCreate).unwrap(),
-                    &serde_json::to_string(&paths).unwrap(),
-                ));
-            }
-            Event::FileSystemUpdate(paths) => {
-                let paths: Vec<String> = paths
-                    .iter()
-                    .map(|p| p.to_string_lossy().to_string())
-                    .collect();
-                post_message_to(PluginMessage::new_to_worker(
-                    "file_name_search",
-                    &serde_json::to_string(&MessageToSearch::FileSystemUpdate).unwrap(),
-                    &serde_json::to_string(&paths).unwrap(),
-                ));
-                post_message_to(PluginMessage::new_to_worker(
-                    "file_contents_search",
-                    &serde_json::to_string(&MessageToSearch::FileSystemUpdate).unwrap(),
-                    &serde_json::to_string(&paths).unwrap(),
-                ));
-            }
-            Event::FileSystemDelete(paths) => {
-                let paths: Vec<String> = paths
-                    .iter()
-                    .map(|p| p.to_string_lossy().to_string())
-                    .collect();
-                post_message_to(PluginMessage::new_to_worker(
-                    "file_name_search",
-                    &serde_json::to_string(&MessageToSearch::FileSystemDelete).unwrap(),
-                    &serde_json::to_string(&paths).unwrap(),
-                ));
-                post_message_to(PluginMessage::new_to_worker(
-                    "file_contents_search",
-                    &serde_json::to_string(&MessageToSearch::FileSystemDelete).unwrap(),
-                    &serde_json::to_string(&paths).unwrap(),
-                ));
             }
             _ => {
                 eprintln!("Unknown event: {}", event.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,14 @@ impl ZellijPlugin for State {
     fn load(&mut self, config: BTreeMap<String, String>) {
         self.loading = true;
         self.kiosk_mode = config.get("kiosk").map(|k| k == "true").unwrap_or(false);
+        if let Some(search_type) = config.get("search_filter") {
+            match search_type.as_str() {
+                "file_names" => self.search_filter = SearchType::Names,
+                "file_contents" => self.search_filter = SearchType::Contents,
+                "all" => self.search_filter = SearchType::NamesAndContents,
+                _ => {}
+            }
+        }
         request_permission(&[
             PermissionType::OpenFiles,
             PermissionType::ChangeApplicationState,

--- a/src/ui/controls_line.rs
+++ b/src/ui/controls_line.rs
@@ -23,14 +23,7 @@ impl ControlsLine {
         self.animation_offset = animation_offset;
         self
     }
-    pub fn render(&self, max_width: usize, show_controls: bool) -> String {
-        if show_controls {
-            self.render_controls(max_width)
-        } else {
-            self.render_empty_line(max_width)
-        }
-    }
-    pub fn render_controls(&self, max_width: usize) -> String {
+    pub fn render(&self, max_width: usize) -> String {
         let loading_animation =
             LoadingAnimation::new(&self.scanning_indication, self.animation_offset);
         let full_length = loading_animation.full_len()

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -71,7 +71,6 @@ impl State {
         }
     }
     pub fn render_controls_line(&self) -> String {
-        let has_results = !self.displayed_search_results.1.is_empty();
         let tiled_floating_control =
             Control::new_floating_control("Ctrl f", self.should_open_floating);
         let names_contents_control = Control::new_filter_control("Ctrl r", &self.search_filter);
@@ -86,10 +85,10 @@ impl State {
                 Some(vec!["Scanning folder", "Scanning", "S"]),
             )
             .with_animation_offset(self.loading_animation_offset)
-            .render(self.display_columns, has_results)
+            .render(self.display_columns)
         } else {
             ControlsLine::new(controls, None)
-                .render(self.display_columns, has_results)
+                .render(self.display_columns)
         }
     }
 }


### PR DESCRIPTION
This includes:
1. Removing the filesystem listening interface - this should improve performance and resource utilization significantly
2. Fix some issues with wide-char rendering
3. Allow configuring the search_filter on startup. It can be one of `search_filter "file_names"`, `search_filter "file_contents"`, `search_filter "all"` (the last being the default)